### PR TITLE
Support GHC 9.2.4

### DIFF
--- a/cli-git.cabal
+++ b/cli-git.cabal
@@ -12,14 +12,14 @@ build-type:         Simple
 extra-source-files: CHANGELOG.md
                     README.md
 
-tested-with: GHC ==8.6.5 || ==8.8.4
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==9.2.4
 
 library
   exposed-modules:  Bindings.Cli.Git
   hs-source-dirs:   src
   default-language: Haskell2010
   build-depends:
-      base            >=4.12.0.0 && <4.15
+      base            >=4.12.0.0 && <4.17
     , cli-extras      >=0.2.1.0  && <0.3
     , containers      >=0.6.0.1  && <0.7
     , data-default    >=0.7.1.1  && <0.8

--- a/cli-git.cabal
+++ b/cli-git.cabal
@@ -24,7 +24,6 @@ library
     , containers      >=0.6.0.1  && <0.7
     , data-default    >=0.7.1.1  && <0.8
     , exceptions      >=0.10.3   && <0.11
-    , lens            >=4.17.1   && <4.20
     , logging-effect  >=1.3.4    && <1.4
     , megaparsec      >=7.0.5    && <9.1
     , mtl             >=2.2.2    && <2.3


### PR DESCRIPTION
This loosens the bounds on `base` so that it can be run on a later version of GHC

I haven't bumped the package version as it should be possible to do a metadata revision on Hackage